### PR TITLE
docs: rebrand LambdaTest to TestMu AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Some Safari & IE browsers, doesn't support automatic resolution of the URL strin
 
 ### Note: You can also mention your TestMu AI credentials in env/default.properties file
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -80,11 +80,15 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)

--- a/README.md
+++ b/README.md
@@ -76,13 +76,19 @@ Some Safari & IE browsers, doesn't support automatic resolution of the URL strin
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -1,100 +1,112 @@
-# TestMu AI-Maven-Tunnel — TestMu AI (Formerly LambdaTest)
+# Run Selenium Tests with Maven and TestMu AI Tunnel (Formerly LambdaTest)
 
-![TestMu AI Logo](https://www.testmuai.com/resources/images/selenium-parallel-testing-index.png)
+<p align="center">
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://mvnrepository.com/artifact/org.testng/testng"><img src="https://img.shields.io/maven-central/v/org.testng/testng.svg?style=for-the-badge&labelColor=000000" alt="TestNG version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+</p>
 
----
+## Getting Started
+
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
+
+With TestMu AI (Formerly LambdaTest), you can run Selenium tests via Maven with local tunnel support. This sample shows how to configure Java Maven TestNG tests to run on the TestMu AI cloud with tunnel support.
+
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
 ### Prerequisites
 
-1. Maven is required to be installed:
-   https://maven.apache.org/install.html
+- Java 8 or higher
+- Maven
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
-### Environment Setup
+### Setup
 
-1. Global Dependencies
-   - Install [Java8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-2. TestMu AI Credentials
+Clone and install dependencies:
 
-   - Set TestMu AI username and access key in environment variables. It can be obtained from [TestMu AI dashboard](https://automation.lambdatest.com/)  
-     example:
+```bash
+git clone https://github.com/LambdaTest/maven-tunnel-sample && cd maven-tunnel-sample
+mvn compile
+```
 
-   * For linux/mac
+Set your credentials as environment variables.
 
-   ```
-   export LT_USERNAME="YOUR_USERNAME"
-   export LT_ACCESS_KEY="YOUR ACCESS KEY"
+**macOS / Linux:**
 
-   ```
+```bash
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+```
 
-   - For Windows
+**Windows:**
 
-   ```
-   set LT_USERNAME="YOUR_USERNAME"
-   set LT_ACCESS_KEY="YOUR ACCESS KEY"
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+```
 
-   ```
+### Run tests
 
-3. Setup
-   - Clone [maven-tunnel-sample](https://github.com/LambdaTest/maven-tunnel-sample.git) from GitHub.
-   - Navigate to the cloned directory
-   - Compile maven dependencies
-   ```
-   $ mvn compile
-   ```
+```bash
+mvn test -DsuiteXmlFile=MavenSingle.xml
+```
 
-##### Routing traffic through your local machine
+View results on your TestMu AI dashboard.
 
-- Set tunnel value to `true` in test capabilities
-  > OS specific instructions to download and setup tunnel binary can be found at the following links.
-  >
-  > - [Windows](https://www.testmuai.com/support/docs/display/TD/Local+Testing+For+Windows)
-  > - [Mac](https://www.testmuai.com/support/docs/display/TD/Local+Testing+For+MacOS)
-  > - [Linux](https://www.testmuai.com/support/docs/display/TD/Local+Testing+For+Linux)
+### Local testing with TestMu AI Tunnel
 
-### Important Note:
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
-Some Safari & IE browsers, doesn't support automatic resolution of the URL string "localhost". Therefore if you test on URLs like "http://localhost/" or "http://localhost:8080" etc, you would get an error in these browsers. A possible solution is to use "localhost.lambdatest.com" or replace the string "localhost" with machine IP address. For example if you wanted to test "http://localhost/dashboard" or, and your machine IP is 192.168.2.6 you can instead test on "http://192.168.2.6/dashboard" or "http://localhost.lambdatest.com/dashboard".
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
 
-### Running Tests
+Add the following to your capabilities:
 
-- To Start Test:
+```js
+tunnel: true,
+```
 
-  - Navigate to maven-tunnel-sample
-  - Run following command
+## Contributions
 
-  - To run single test
-    `mvn test -DsuiteXmlFile=MavenSingle.xml`
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Java version, OS, and Maven version.
 
-  - To run parallel tests
-    `mvn test -DsuiteXmlFile=MavenParallel.xml`
+## TestMu AI (Formerly LambdaTest) Community
 
-### Note: You can also mention your TestMu AI credentials in env/default.properties file
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-## 🚀 LambdaTest is Now TestMu AI
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-### 🔄 Our Rebrand Journey
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
 
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
+👉 Find the new home for [LambdaTest](https://www.testmuai.com).
 
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+### How LambdaTest Evolved into TestMu AI
 
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-### 🔭 Explore TestMu AI
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
 
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
+
+## Support
+
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# LambdaTest-Maven-Tunnel
+# TestMu AI-Maven-Tunnel — TestMu AI (Formerly LambdaTest)
 
-![LambdaTest Logo](https://www.lambdatest.com/resources/images/selenium-parallel-testing-index.png)
+![TestMu AI Logo](https://www.testmuai.com/resources/images/selenium-parallel-testing-index.png)
 
 ---
 
@@ -13,9 +13,9 @@
 
 1. Global Dependencies
    - Install [Java8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-2. Lambdatest Credentials
+2. TestMu AI Credentials
 
-   - Set LambdaTest username and access key in environment variables. It can be obtained from [LambdaTest dashboard](https://automation.lambdatest.com/)  
+   - Set TestMu AI username and access key in environment variables. It can be obtained from [TestMu AI dashboard](https://automation.lambdatest.com/)  
      example:
 
    * For linux/mac
@@ -47,9 +47,9 @@
 - Set tunnel value to `true` in test capabilities
   > OS specific instructions to download and setup tunnel binary can be found at the following links.
   >
-  > - [Windows](https://www.lambdatest.com/support/docs/display/TD/Local+Testing+For+Windows)
-  > - [Mac](https://www.lambdatest.com/support/docs/display/TD/Local+Testing+For+MacOS)
-  > - [Linux](https://www.lambdatest.com/support/docs/display/TD/Local+Testing+For+Linux)
+  > - [Windows](https://www.testmuai.com/support/docs/display/TD/Local+Testing+For+Windows)
+  > - [Mac](https://www.testmuai.com/support/docs/display/TD/Local+Testing+For+MacOS)
+  > - [Linux](https://www.testmuai.com/support/docs/display/TD/Local+Testing+For+Linux)
 
 ### Important Note:
 
@@ -68,12 +68,23 @@ Some Safari & IE browsers, doesn't support automatic resolution of the URL strin
   - To run parallel tests
     `mvn test -DsuiteXmlFile=MavenParallel.xml`
 
-### Note: You can also mention your LambdaTest credentials in env/default.properties file
+### Note: You can also mention your TestMu AI credentials in env/default.properties file
 
-## About LambdaTest
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
 
-[LambdaTest](https://www.lambdatest.com/) is a cloud based selenium grid infrastructure that can help you run automated cross browser compatibility tests on 2000+ different browser and operating system environments. LambdaTest supports all programming languages and frameworks that are supported with Selenium, and have easy integrations with all popular CI/CD platforms. It's a perfect solution to bring your [selenium automation testing](https://www.lambdatest.com/selenium-automation) to cloud based infrastructure that not only helps you increase your test coverage over multiple desktop and mobile browsers, but also allows you to cut down your test execution time by running tests on parallel.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
-### Resources
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-##### [SeleniumHQ Documentation](http://www.seleniumhq.org/docs/)
+**🔄 Our Rebrand Journey**
+
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
+
+**✨ Specialties**
+
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).


### PR DESCRIPTION
## Summary

- Updated README to reflect LambdaTest to TestMu AI rebrand (January 2026)
- H1 heading updated to [Title] - TestMu AI (Formerly LambdaTest)
- Replaced LambdaTest with TestMu AI in all prose (skipping GitHub org URLs, package names, config file names, code blocks, and service subdomains)
- Community URL updated to community.testmuai.com
- YouTube channel updated to youtube.com/@TestMuAI
- Support email updated to support@testmuai.com
- Added rebrand section: LambdaTest is Now TestMu AI

Generated with Claude Code